### PR TITLE
Upstream updates

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,5 +9,6 @@ name = "stm32f429x"
 version = "0.3.0"
 
 [dependencies]
-cortex-m = "0.2.4"
+cortex-m = "0.4.0"
 vcell = "0.1.0"
+bare-metal = "0.1.1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,6 +9,6 @@ name = "stm32f429x"
 version = "0.3.0"
 
 [dependencies]
-cortex-m = "0.4.0"
+cortex-m = "0.4.3"
 vcell = "0.1.0"
 bare-metal = "0.1.1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,12 @@ documentation = "https://docs.rs/stm32f429x"
 name = "stm32f429x"
 version = "0.3.0"
 
+[features]
+default = []
+rt = ["cortex-m-rt"]
+
 [dependencies]
 cortex-m = "0.4.3"
 vcell = "0.1.0"
 bare-metal = "0.1.1"
+cortex-m-rt = { version = "0.3.12", optional = true }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,12 +1,12 @@
 [package]
-authors = ["David Karwowski <karwowski.david@gmail.com>"]
-description = "Peripheral access API for STM32F429X Microcontrollers."
+authors = ["Astro <astro@spaceboyz.net>"]
+description = "Peripheral access API for STM32F429 Microcontrollers."
 keywords = ["no-std", "arm", "cortex-m", "stm32"]
 license = "MIT"
-repository = "https://github.com/dkarwowski/stm32f429x"
-documentation = "https://docs.rs/stm32f429x"
-name = "stm32f429x"
-version = "0.3.0"
+repository = "https://github.com/astro/stm32f429x"
+documentation = "https://docs.rs/stm32f429"
+name = "stm32f429"
+version = "0.0.0"
 
 [features]
 default = []

--- a/README.md
+++ b/README.md
@@ -1,3 +1,7 @@
-# stm32f429x
+# stm32f429
 
-Peripheral Access API built with [svd2rust](https://github.com/japaric/svd2rust).
+Peripheral Access API built with the latest
+[svd2rust](https://github.com/japaric/svd2rust). In contrast to the
+[stm32f429x](https://github.com/dkarwowski/stm32f429x/) crate, this
+one contains no custom additions but aims to follow up with the latest
+`STM32F429.svd` with the current `svd2rust` tool.


### PR DESCRIPTION
There have been breaking changes in svd2rust and the cortex-m crate. I re-ran svd2rust. Unfortunately, this drops all of the manual improvements.